### PR TITLE
Initial reusable workflow implementation

### DIFF
--- a/.github/workflows/toradex-deb-ci.yml
+++ b/.github/workflows/toradex-deb-ci.yml
@@ -1,0 +1,110 @@
+# Copyright (c) 2024 Toradex AG
+# SPDX-License-Identifier: GPL-3.0-only
+
+name: Toradex Debian CI
+
+on:
+  workflow_call:
+    inputs:
+      apt-opts:
+        description: 'Options to be passed to apt-get in the build step'
+        required: false
+        type: string
+      arch:
+        default: amd64
+        description: 'Architecture to build the package'
+        type: string
+      buildpackage-opts:
+        default: '--build=binary --no-sign'
+        description: 'Options to be passed to dpkg-buildpackage'
+        required: false
+        type: string
+      distribution:
+        default: 'sid'
+        description: 'The Debian distribution to run piuparts in'
+        type: string
+      docker-image:
+        default: debian:unstable
+        description: 'Name of a Docker image or path of a Dockerfile to use for the build container'
+        required: false
+        type: string
+      extra-build-deps:
+        description: 'Extra packages to be installed as build dependencies'
+        required: false
+        type: string
+      extra-packages:
+        description: 'Extra packages to be installed in the build environment'
+        required: false
+        type: string
+      extra-repos:
+        description: 'Extra APT repositories to configure in the build environment (one-line-style or deb822-style format)'
+        required: false
+        type: string
+      package-name:
+        description: 'Name of the package being built'
+        required: true
+        type: string
+      run-attestation:
+        default: false
+        description: 'Whether to run attestation to build artifacts or not after the build'
+        required: false
+        type: boolean
+      run-piuparts:
+        default: true
+        description: 'Whether to run piuparts test or not after the build'
+        required: false
+        type: boolean
+      upload-artifacts:
+        default: true
+        description: 'Whether to save build artifacts or not'
+        required: false
+        type: boolean
+
+jobs:
+  build-debs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up binfmt with qemu
+        uses: docker/setup-qemu-action@v3
+        if: ${{ inputs.arch != 'amd64' }} 
+
+      - name: Build Debian Package
+        uses: jtdor/build-deb-action@v1
+        with:
+          apt-opts: ${{ inputs.apt-opts }}
+          buildpackage-opts: ${{ inputs.buildpackage-opts }}
+          docker-image: ${{ inputs.docker-image }}
+          extra-build-deps: ${{ inputs.extra-build-deps }}
+          extra-docker-args: --platform ${{ inputs.arch }}
+          extra-repo-keys: ${{ inputs.extra-repo-keys }}
+          extra-repos: ${{ inputs.extra-repos }}
+          setup-hook: "apt update; apt install -y -q ${{ inputs.extra-packages }}"
+
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        if: ${{ inputs.run-attestation }}
+        with:
+          subject-path: 'debian/artifacts*'
+
+      - name: Generating artifact directory name
+        run: echo "artifacts=${{ inputs.package-name }}-${{ inputs.arch }}" >> $GITHUB_ENV
+        if: ${{ inputs.upload-artifacts }}
+
+      - name: Upload Workflow Artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload-artifacts }}
+        with:
+          name: ${{ env.artifacts }}
+          path: debian/artifacts/*
+          retention-days: 90
+
+      - name: Run piuparts test
+        uses: evgeni/action-piuparts@b6520bd02312076d3148b57ff3109dea1145bf0d
+        if: ${{ inputs.run-piuparts }}
+        with:
+          package: debian/artifacts/*.changes
+          base-image: ${{ inputs.docker-image }}
+          distribution: ${{ inputs.distribution }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,164 @@
+# Toradex Debian CI reusable workflow
+
+This reusable workflow allows one to build, publish, attest and test debian
+packages. It has many options to enable/disable features and can configured to
+meet many needs.
+
+## Inputs
+
+## `apt-opts`
+Options to be passed to apt-get in the build step.
+
+Default `""`.
+
+## `arch`
+Architecture to build the package.
+
+Default `"amd64"`.
+
+## `buildpackage-opts`
+Options to be passed to dpkg-buildpackage.
+
+Default `"--build=binary --no-sign"`.
+
+## `distribution`
+The Debian distribution to run piuparts in.
+
+Default `"sid"`.
+
+## `docker-image`
+Name of a Docker image or path of a Dockerfile to use for the build container.
+
+Default `"debian:unstable"`.
+
+## `extra-build-deps`
+Extra packages to be installed as build dependencies.
+
+Default `""`.
+
+## `extra-packages`
+Extra packages to be installed in the build environment.
+
+Default `""`.
+
+## `extra-repos`
+Extra APT repositories to configure in the build environment (one-line-style or deb822-style format).
+
+Default `""`.
+
+## `package-name`
+**Required** Name of the package being built.
+
+Default `""`.
+
+## `run-attestation`
+Whether to run attestation to build artifacts or not after the build.
+
+Default `false`.
+
+## `run-piuparts`
+Whether to run piuparts test or not after the build.
+
+Default `true`.
+
+## `upload-artifacts`
+Whether to save build artifacts or not.
+
+Default `true`.
+
+
+## Example usage
+
+Just build neofetch for Debian unstable:
+
+```
+uses: torizon/toradex-deb-ci@v0
+with:
+  package-name: 'neofetch'
+```
+
+Build neofetch for Debian bookworm with attestation and not running piuparts test:
+
+```
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+uses: torizon/toradex-deb-ci@v0
+with:
+  package-name: 'neofetch'
+  docker-image: 'debian:bookworm'
+  run-attestation: true
+  run-piuparts: false
+```
+
+Build neofetch for Debian bookworm with 3rd party feeds:
+
+```
+uses: torizon/toradex-deb-ci@v0
+with:
+  package-name: 'neofetch'
+  distribution: 'bookworm'
+  docker-image: 'debian:bookworm'
+extra-packages: ca-certificates
+extra-repos: |
+      Types: deb
+      URIs: https://feeds.toradex.com/debian
+      Suites: testing
+      Components: main non-free
+      Signed-By: -----BEGIN PGP PUBLIC KEY BLOCK-----
+       .
+       mQINBGUJ0fgBEADe+nvFNajvFQQPGXXLixVz4/+xLGdnmgGef6Oe4DPuIFD7WATJ
+       hzH8ng+elAHVIkfrV7+j9lGWnozcBqBdvHoz46Y2EE1nk3no78aUdy+9b0wx3yWe
+       tqY29Nu3yVD8d64e5fuGq4PKJB1gtFkWhEfFwTmq3uiRQRfAy60DERTDF7bocQsW
+       hTVjc/Lr1lj4POB0HlUhzIj84o/y5SV50F0oqpJdjfu6Bbp/XVHklF4GNBabaFVf
+       iF11306eWKcKM2yZI4MJhAPTaTSFS51Z81lbQkyLjQzfdxAvSSsNWUUS8A3IYBhi
+       IwyeIS3jPtBcIDPcxKDB8rio8j6eKq0FtnW1WTVMmDdBqLlE71y2Av2d2W4ySqf+
+       huvhRPqCVMgsr09oHUOka19cX82YTYiMOU3/+UsKZ2DJT0w+k2z5DOirzf5SNbcA
+       hlc8WcjavrYTqVysB7IIQx+WsYosRXOSWMmbY+3fk5lpnz/ZZfluiz36krdYxIdd
+       MtiaUtrRZvj0hpbe85alUaqVJ87k1TrA5URpXV0ZOgV753QWOtjcclEroRIINEzZ
+       bwBjZlRrPFos/VSbsx0/2MTEkxLI/bakOihpZ53f4uhwrv8Kc7+lDLP51N8t2UAM
+       sORmkLsNQUdCxM8Ary+fl2h1DvvgqxE2F3uzIrpM8DgGC0+Ln8jS+vEgBQARAQAB
+       tChUb3JhZGV4IEFHIDxkZWJpYW4tcGtnLXRlYW1AdG9yYWRleC5jb20+iQJOBBMB
+       CgA4FiEExxIbHghPt0MdjZudxpwk2XUKkDAFAmUJ0fgCGwMFCwkIBwIGFQoJCAsC
+       BBYCAwECHgECF4AACgkQxpwk2XUKkDBmAhAAklMNV3sAN4fGfBmgOLQDkJJE6plL
+       qAbV9NeRJ1XN4SfDY9K7b/7K3HYmge9ojj/tVcISYIflehkFJBVhj8gK+9EH74xW
+       PHz711i4hqRvAfHFbjJNhluDdiYmqHnF6OWHffr1DrSYZ32WykcSl4Iy0VU2LRZA
+       92kAokZwTLFQNQQLW0lZSTtyyFfQPbtuk+7RBHTOcbr0HYojM41Poj4rpOiAhgmS
+       gZlO1G39s/efPKJGXfr1jZdCVJP8yVG3A3tcYMhR5mwrZ6oVR5Rup8JTrHCenGhK
+       +gwgtqzRhuLwX9GOsxbJyCnPkZv694bu3Epaz8b+jeB9jAHSnLlv6QH+BtVcJbg7
+       vIRiykaLgx1M/goeTMLGEyHPgWbXYJmqeoRXMwkAsRFTPUzgBC5CaAniDiLSQ726
+       ppW9l5YHgozU/eaaxqkPjRFrEUqFgN919CW4NwX65L2ENIdH2AMF4AumFFEtmw8l
+       nPul2VCUHlA1+i31KiO5l0tNituPVolp/Gh/nmTnKNTaU7xp1B7Ph001x0q54k6l
+       GebRSj+d+pzAvzuy1GKSKIMqYUv4pfJyEZq1jRJe4faLxXCdIADbfo5UqOD+A2L3
+       QqLwRypTW8gYRjnPWar33xo1Y2QQ1bbn3+Kp+h27hWvUmimlwdf+xz0VFtAPiBlp
+       pdViHFsGt78rMFC5Ag0EZQnR+AEQAMedkYK5MHNu0dwnVAIIXLfxHWHOtLp2r31A
+       k+DsOJjVM3ob3iJ1I3AOJFTtNem6r8dXXfYYFiABe9eIAKY1xwVw6TSgCisLkvGn
+       pzE/Ul2GXBjWmZTnoqm4eNft3r7VyjvV6qplEdHjneaYnKsAsJDN+/zfnYiNnl0D
+       ikYWPTe27/kSQsOgA6rr3wBs//FGF0kgl9T4+EKzsDpDsiJMu9fjEeiW5z3SrTVQ
+       VGG34ikG3IRpwJYsBLSLjBXYW8DU8d4p8aNKCkqchJv8ymaoOsSfx3HLGH359AxB
+       4fsWJSKHH2RmQ6pHbaWM3A7XrR1zn3vb3yn5dzdkCchTtdgvYUgC5T8d75WYzMWp
+       1LCvdxnTXUoECFXGWBicq8bw42bfiw4929T3PtWpFqvPLBlMlZBqTNBW65mvGkeP
+       aChgq4A4sxLQcfAkQf5S0woss1W3wJ/04XjoLNm0XYwTEepe5Mva//NmHwMBIpN6
+       pKE2VmnzPBJXbwU0TAcfhbXR9IEUk8RUcxwaCThcBh4Oie6+ZusVevcoS8UjGF08
+       3IFJV/mJZAdNZvcaNuHTcdHIPi3dD/M3nkjeK0kDj+Exg1Lct/UbDO6NidE7Ayte
+       rRmZETngxeeo4S1gmdteKulKmHcu/IvN+xhSkettuIYWJq7jwfglxakIcCIOY8yw
+       8zpF4+ZZABEBAAGJAjYEGAEKACAWIQTHEhseCE+3Qx2Nm53GnCTZdQqQMAUCZQnR
+       +AIbDAAKCRDGnCTZdQqQMChiEADGSFk2G0QrGDRg489okGz31mNa9ggISNREkIY8
+       MUZ/rbdeOdG66EMVW/zLmNTYbEZdJrYbLSO1zRznACWD1wuvqsFn3q0sG3a/VnVE
+       wx38h6sD7lizqSSotneQUhm5EVAoA0D0V8xYz5oPvogFifHs0TBEaPHGQ8Xy88Ep
+       tnGceKfceroS2z6pehZDGpSMpSgNIkJ8ay2aTZEF4A21uUGZSmB6nfUWmGob1/yk
+       t7OFIVpO+1QTVa3MyfxwUSDriQtjhVkV7Kj5R06UmuDibj/LFlhK2Nn1NpZY2yjH
+       yjPrwDZiqfWhuP5XyvVHAXJT2Am7e+wt1odQMBjtytAQ1UmpamTiKZMIsU/lh/qV
+       5D0Rb8GPJXn0YqgoUTqa8uGbExdEfNxnoegcF2wUaOQoZk9yjOQc26QRV/6QVO5M
+       th41p/ZxuTPVJAs76MPPpeNFT9xZmsP+LWE2awaWYTTk+aAmgQQIHyqJqc/QRYsw
+       KKcWF/U+7aKlt2J24v7RFIMkNSRL9UiYcNhMgIJVIw2NkWlF4LoDRQ8l8DMD4St3
+       eKYPMo0laD2+Z4ul7hUjY7pHSDSO+erfySkFpvx83XgtF9d0uJdMXQ3gRuFhwtK7
+       Grl7Vu/9cvNCWtBq5/hNdGU1d4Y1HoAK6sooRbwy0JUaXHq08MDhpWQysmPpHBKX
+       CvvuQQ==
+       =VfKA
+       -----END PGP PUBLIC KEY BLOCK-----
+```
+
+## License
+This project is licensed under the terms of GPLv3 license - see `LICENSE`.


### PR DESCRIPTION
This reusable workflow builds on top of other actions and act as the interface for them. In this way, every change in the workflow is done in a unique and centralized place instead of MRing many repos.

Initial options allowed are:
- build package;
- publish artifacts;
- attest artifacts;
- run piuparts.