### PR TITLE
New input parameter to set the runner for the workflow

### DIFF
--- a/.github/workflows/toradex-deb-ci.yml
+++ b/.github/workflows/toradex-deb-ci.yml
@@ -55,6 +55,11 @@ on:
         description: 'Name of the package being built'
         required: true
         type: string
+      runner-system:
+        description: 'Runner system where the workflow is executed'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
       run-attestation:
         default: false
         description: 'Whether to run attestation to build artifacts or not after the build'
@@ -78,7 +83,7 @@ on:
 
 jobs:
   build-debs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-system }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Implements what is discussed in #8 and [on Toradex community](https://community.toradex.com/t/mouse-and-touch-screen-dont-work-with-cog-imx8-container/25291/13)

Closes: torizon/torizon-deb-ci#8